### PR TITLE
Changed hard-coded BanTime of elapsed.Days > 0 to use app.config value.

### DIFF
--- a/IPBanService.cs
+++ b/IPBanService.cs
@@ -278,7 +278,7 @@ popd
             {
                 TimeSpan elapsed = now - keyValue.Value;
 
-                if (elapsed.Days > 0)
+                if (elapsed > config.BanTime)
                 {
                     Log.Write(LogLevel.Error, "Un-banning ip address {0}", keyValue.Key);
                     lock (ipBlocker)


### PR DESCRIPTION
 Changed hard-coded bantime to use app.config value. This allows for a ban duration to be seconds, minutes, hours, days, etc.
