### PR TITLE
Added feature to forget IPs that have not made an invalid login attempt within a certain amount of time.

### DIFF
--- a/IPBan.csproj
+++ b/IPBan.csproj
@@ -58,6 +58,7 @@
     <Compile Include="IPBanService.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="IPBlockCount.cs" />
     <Compile Include="Logger.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/IPBanConfig.cs
+++ b/IPBanConfig.cs
@@ -22,6 +22,7 @@ namespace IPBan
         private int failedLoginAttemptsBeforeBan = 5;
         private TimeSpan banTime = TimeSpan.FromDays(1.0d);
         private string banFile = "banlog.txt";
+        private TimeSpan expireTime = TimeSpan.FromDays(1.0d);
         private TimeSpan cycleTime = TimeSpan.FromMinutes(1.0d);
         private string ruleName = "BlockIPAddresses";
         private readonly HashSet<string> whiteList = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -45,6 +46,9 @@ namespace IPBan
                 banFile = Path.GetFullPath(banFile);
             }
 
+            value = ConfigurationManager.AppSettings["ExpireTime"];
+            expireTime = TimeSpan.Parse(value);
+            
             value = ConfigurationManager.AppSettings["CycleTime"];
             cycleTime = TimeSpan.Parse(value);
 
@@ -97,6 +101,11 @@ namespace IPBan
         /// </summary>
         public string BanFile { get { return banFile; } }
 
+        /// <summary>
+        /// The duration after the last failed login attempt that the count is reset back to 0.
+        /// </summary>
+        public TimeSpan ExpireTime { get { return expireTime; } }
+        
         /// <summary>
         /// Interval of time to do house-keeping chores like un-banning ip addresses
         /// </summary>

--- a/IPBlockCount.cs
+++ b/IPBlockCount.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace IPBan
+{
+    public class IPBlockCount
+    {
+        public int Count { get; set; }
+        public DateTime LastFailedLogin { get; set; }
+
+        public IPBlockCount()
+        {
+        }
+
+        public IPBlockCount(int count)
+            : this()
+        {
+            Count = count;
+            LastFailedLogin = DateTime.UtcNow;
+        }
+
+        public void IncrementCount()
+        {
+            Count++;
+            LastFailedLogin = DateTime.UtcNow;
+        }
+    }
+}

--- a/app.config
+++ b/app.config
@@ -71,6 +71,9 @@
     <!-- The file to store banned ip addresses in -->
     <add key="BanFile" value="banlog.txt" />
 
+    <!-- The duration after the last failed login attempt that the ip is forgotten (count reset back to 0). Set to 00:00:00:00 to never forget an ip. (DD:HH:MM:SS) -->
+    <add key="ExpireTime" value="00:00:30:00" />
+
     <!-- The time between cycles to do house-keeping such as un-banning ip addresses, reloading config, etc. (DD:HH:MM:SS) -->
     <add key="CycleTime" value="00:00:00:15" />
 


### PR DESCRIPTION
Great tool. I've been looking for a while, for a way to block those annoying brute force hack attempts. I've added another tweak:

Added feature to forget IPs that have not made an invalid login attempt within a certain amount of time.
Example: An IP is forgotten (count reset back to 0) if it waits 30 minutes after its last failed login attempt.

This allows for the case where a user enters the wrong password once, but then successfully logs in. Previously, the blocker would still hold a count of 1 for his IP. In this case, the user could end up being banned over a period of time from entering the password incorrectly just once each session, even though he remembers his password eventually (maybe a month down the line if the service remained running that long, he enters the password wrong for the Nth time and gets blocked). This new option resets him back to 0 after a certain amount of time.

The option can also be disabled by just setting it to 00:00:00:00.

To test it, edit the app.config:
FailedLoginAttemptsBeforeBan = 3
BanTime = 00:00:00:20
ExpireTime = 00:00:00:20

Run:
99.99.99.99 gets banned immediately from 3 test failed login attempts.
99.99.99.98 gets a count of 1 from 1 test failed login attempt.
99.99.99.100 gets a count of 1 from 1 test failed login attempt.

99.99.99.98 gets a count of 2 about 15 seconds later from a delayed test failed login attempt.
99.99.99.99 gets unbanned

99.99.99.100 gets forgotten after the ExpireTime delay (never got banned)

99.99.99.98 gets forgotten a bit later since it had a more recent test failed login attempt (never got banned)
