### PR TITLE
Process runner

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+2018-01-09 (Chad Cooper)
+- Added ability to run an external program on IP ban.
+
 2017-08-09 (Jeff Johnson)
 - Add additional instructions about audit policy.
 - Add another XML test.

--- a/IPBanConfig.cs
+++ b/IPBanConfig.cs
@@ -147,7 +147,7 @@ namespace IPBan
                 }
             }
 
-            _processToRunOnBan = ConfigurationManager.AppSettings["ProcessToRun"];
+            _processToRunOnBan = ConfigurationManager.AppSettings["ProcessToRunOnBan"];
         }
 
         /// <summary>
@@ -247,7 +247,7 @@ namespace IPBan
 
         public string ProcessToRunOnBan(string ipAddress = "")
         {
-            return string.IsNullOrEmpty(ipAddress) ? _processToRunOnBan : _processToRunOnBan.Replace("###IPADDRESS###", ipAddress);
+            return string.IsNullOrWhiteSpace(_processToRunOnBan) ? _processToRunOnBan : _processToRunOnBan.Replace("###IPADDRESS###", ipAddress);
         }
     }
 }

--- a/IPBanConfig.cs
+++ b/IPBanConfig.cs
@@ -32,6 +32,7 @@ namespace IPBan
         private Regex blackListRegex;
         private readonly HashSet<string> allowedUserNames = new HashSet<string>();
         private bool banFileClearOnRestart;
+        private readonly string _processToRunOnBan;
 
         /// <summary>
         /// Checks whether a user name should be banned after a failed login attempt. Cases where this would happen would be if the config has specified an allowed list of user names.
@@ -145,6 +146,8 @@ namespace IPBan
                     expression.RegexObject = new Regex(expression.Regex, RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.CultureInvariant | RegexOptions.Compiled);
                 }
             }
+
+            _processToRunOnBan = ConfigurationManager.AppSettings["ProcessToRun"];
         }
 
         /// <summary>
@@ -241,5 +244,10 @@ namespace IPBan
         /// Allowed user names as a comma separated string
         /// </summary>
         public string AllowedUserNames { get { return string.Join(",", allowedUserNames); } }
+
+        public string ProcessToRunOnBan(string ipAddress = "")
+        {
+            return string.IsNullOrEmpty(ipAddress) ? _processToRunOnBan : _processToRunOnBan.Replace("###IPADDRESS###", ipAddress);
+        }
     }
 }

--- a/IPBanService.cs
+++ b/IPBanService.cs
@@ -322,11 +322,16 @@ namespace IPBan
                                     ipAddressesAndBanDate[ipAddress] = dateTime;
 
                                     // Run a process if one is in config
-                                    if (!string.IsNullOrWhiteSpace(config.ProcessToRunOnBan()))
+                                    var programToRunConfigString = config.ProcessToRunOnBan(ipAddress);
+                                    if (!string.IsNullOrWhiteSpace(programToRunConfigString))
                                     {
                                         try
                                         {
-                                            Process.Start(config.ProcessToRunOnBan(ipAddress));
+                                            var firstSpaceIndex = programToRunConfigString.IndexOf(" ", StringComparison.Ordinal);
+                                            var program = programToRunConfigString.Substring(0, firstSpaceIndex);
+                                            var arguments = programToRunConfigString.Remove(0, firstSpaceIndex + 1);
+                                            Log.Write(LogLevel.Error, "Running program {0}; with arguments {1}: ", program, arguments);
+                                            Process.Start(program, arguments);
                                         }
                                         catch (Exception e)
                                         {

--- a/IPBanService.cs
+++ b/IPBanService.cs
@@ -39,6 +39,7 @@ namespace IPBan
         private EventLogQuery query;
         private EventLogWatcher watcher;
 
+
         // note that an ip that has a block count may not yet be in the ipAddressesAndBanDate dictionary
         private Dictionary<string, IPBlockCount> ipAddressesAndBlockCounts = new Dictionary<string, IPBlockCount>();
         private Dictionary<string, DateTime> ipAddressesAndBanDate = new Dictionary<string, DateTime>();
@@ -319,6 +320,20 @@ namespace IPBan
                                 {
                                     Log.Write(LogLevel.Error, "Banning ip address: {0}, user name: {1}, black listed: {2}, count: {3}", ipAddress, userName, blackListed, ipBlockCount.Count);
                                     ipAddressesAndBanDate[ipAddress] = dateTime;
+
+                                    // Run a process if one is in config
+                                    if (!string.IsNullOrWhiteSpace(config.ProcessToRunOnBan()))
+                                    {
+                                        try
+                                        {
+                                            Process.Start(config.ProcessToRunOnBan(ipAddress));
+                                        }
+                                        catch (Exception e)
+                                        {
+                                            Log.Write(LogLevel.Error, "Failed to execute process on ban: {0}", e);
+                                        }
+                                    }
+
                                     ExecuteBanScript();
                                 }
                             }

--- a/IPBanService.cs
+++ b/IPBanService.cs
@@ -330,7 +330,7 @@ namespace IPBan
                                             var firstSpaceIndex = programToRunConfigString.IndexOf(" ", StringComparison.Ordinal);
                                             var program = programToRunConfigString.Substring(0, firstSpaceIndex);
                                             var arguments = programToRunConfigString.Remove(0, firstSpaceIndex + 1);
-                                            Log.Write(LogLevel.Error, "Running program {0}; with arguments {1}: ", program, arguments);
+                                            Log.Write(LogLevel.Error, "Running program: {0} with arguments: {1}", program, arguments);
                                             Process.Start(program, arguments);
                                         }
                                         catch (Exception e)

--- a/app.config
+++ b/app.config
@@ -260,6 +260,11 @@
     -->
     <add key="AllowedUserNames" value="" />
 
+    <!---
+      Run an external process when a ban occurs. ###IPADDRESS### will be replaced with the actual IP which was banned
+    -->
+    <add key="ProcessToRunOnBan" value=""/>
+
   </appSettings>
 
   <startup>


### PR DESCRIPTION
Allows you to run a program when a IP ban occurs. Configured via app.config, enabled when a value is set for key ProcessToRunOnBan, e.g.

<add key="ProcessToRunOnBan" value="pythonw &quot;C:\Scripts\IP Abuse DB\ipAbusedb.py&quot; -r ###IPADDRESS###"/>

###IPADDRESS### is replaced with the IP being banned.