### PR TITLE
Update readme to allowing incoming NTLM traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you still don't see ip addresses being logged, do the following:
 - Make sure to read this stackoverflow thread about ip addresses not getting logged: http://stackoverflow.com/questions/1734635/event-logging-ipaddress-does-not-always-resolve
 - Network security: LAN Manager authentication level -- Send NTLMv2 response only. Refuse LM & NTLM
 - Network security: Restrict NTLM: Audit Incoming NTLM Traffic -- Enable auditing for all accounts
-- Network security: Restrict NTLM: Incoming NTLM traffic -- Deny all accounts
+- Network security: Restrict NTLM: Incoming NTLM traffic -- Allow all accounts
 - Do not allow for passwords to be saved -- Enabled
 - Prompt for credentials on the client computer -- Enabled
 


### PR DESCRIPTION
Since NLA is now supported, setting this to `Deny all accounts` will prevent NLA authentication, and prevent RDP access altogether if NLA is enforced.

Unless of course I'm actually wrong about this and this issue still exists, but #32 implied that the instructions were updated to support NLA when that doesn't seem to be the case, at least for the readme...?

Also, the two following settings after this one only apply to the client/should be set on client and are not at all required.
