### PR TITLE
Made the installer prompt you to select the service startup type

### DIFF
--- a/IPBanCore/Windows/Scripts/install_latest.ps1
+++ b/IPBanCore/Windows/Scripts/install_latest.ps1
@@ -131,7 +131,7 @@ if (Test-Path -Path "$tempPath\nlog.config")
 & auditpol.exe /set /category:"{69979850-797A-11D9-BED3-505054503030}" /success:enable /failure:enable
 
 # create service
-& sc.exe create IPBAN type= own start= auto binPath= $INSTALL_EXE DisplayName= $SERVICE_NAME
+& sc.exe create IPBAN type= own start= delayed-auto binPath= $INSTALL_EXE DisplayName= $SERVICE_NAME
 & sc.exe description IPBAN "Automatically builds firewall rules for abusive login attempts: https://github.com/DigitalRuby/IPBan"
 & sc.exe failure IPBAN reset= 9999 actions= "restart/60000/restart/60000/restart/60000"
 if ($autostart -eq $True)

--- a/IPBanCore/Windows/Scripts/install_latest.ps1
+++ b/IPBanCore/Windows/Scripts/install_latest.ps1
@@ -131,7 +131,7 @@ if (Test-Path -Path "$tempPath\nlog.config")
 & auditpol.exe /set /category:"{69979850-797A-11D9-BED3-505054503030}" /success:enable /failure:enable
 
 # create service
-& sc.exe create IPBAN type= own start= delayed-auto binPath= $INSTALL_EXE DisplayName= $SERVICE_NAME
+& sc.exe create IPBAN type= own start= auto binPath= $INSTALL_EXE DisplayName= $SERVICE_NAME
 & sc.exe description IPBAN "Automatically builds firewall rules for abusive login attempts: https://github.com/DigitalRuby/IPBan"
 & sc.exe failure IPBAN reset= 9999 actions= "restart/60000/restart/60000/restart/60000"
 if ($autostart -eq $True)


### PR DESCRIPTION
Made the installer prompt you to select the service startup type and inform you that the default is "delayed-auto" for non-interactive installs which waits for the higher priority services to start leaving systems unprotected for a short period of time after boot while the recommended is "auto" however when using the latter you may encounter compatibility issues and if you choose to do so you should verify the service starts correctly after reboot.

Resolves: #345