### PR TITLE
  Add documentation for installer script parameters introduced in #347

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,30 @@ $ProgressPreference = 'SilentlyContinue'; [Net.ServicePointManager]::SecurityPro
 ```
 Note: Powershell 5.1 or greater is required.
 
+***Advanced Installation Options***
+
+The installer script supports additional parameters for customization. Due to PowerShell parameter validation introduced in recent updates, you must explicitly specify the `startupType` parameter when using the one-liner installation command.
+
+**Installation with custom startup type:**
+```powershell
+$ProgressPreference = 'SilentlyContinue'; [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iex "& { $((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/DigitalRuby/IPBan/master/IPBanCore/Windows/Scripts/install_latest.ps1')) } -startupType 'delayed-auto'"
+```
+
+Replace `'delayed-auto'` with `'auto'` if you want the service to start immediately on boot (provides immediate protection but may have compatibility issues).
+
+**Available parameters:**
+- `-startupType`: Service startup type - `'delayed-auto'` (default, safer) or `'auto'` (immediate boot protection)
+- `-silent`: `$True` for non-interactive installation, `$False` (default) for interactive mode
+- `-autostart`: `$True` (default) to start service immediately after installation, `$False` to leave stopped
+- `-uninstall`: `'uninstall'` or `'u'` to uninstall IPBan
+
+**Example with multiple parameters:**
+```powershell
+$ProgressPreference = 'SilentlyContinue'; [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iex "& { $((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/DigitalRuby/IPBan/master/IPBanCore/Windows/Scripts/install_latest.ps1')) } -startupType 'auto' -silent `$True -autostart `$True"
+```
+
+**Note:** The `'delayed-auto'` startup type waits for higher priority services to start first, leaving the system briefly unprotected after boot. The `'auto'` option provides immediate protection on boot but may encounter compatibility issues with some system configurations. If you choose `'auto'`, verify the service starts correctly after reboot.
+
 ***Additional Windows Notes***
 - Windows Server 2012 is no longer supported as of October 2023. Please upgrade to a different operating system that is actually supported by Microsoft.
 - Please ensure your server and clients are patched before making the above change: https://support.microsoft.com/en-us/help/4093492/credssp-updates-for-cve-2018-0886-march-13-2018. You need to manually edit group policy as specified in the link.


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation for the Windows  installer script parameters that were introduced in commit #347 but left undocumented.

## Background
Commit #347 (2e954a5) introduced a new `startupType` parameter to the Windows installation script (`install_latest.ps1`), allowing users to choose between `delayed-auto` and `auto` service startup types. While this functionality was added to the script, the README was not updated to reflect these changes.

## Problem
After commit #347, the original one-liner installation command from the README no longer works correctly due to PowerShell parameter validation:

```powershell
# This command now fails with: "The attribute cannot be added because variable
# startupType with value would no longer be valid."
iex ((New-Object System.Net.WebClient).DownloadString('...'))
```

The issue occurs because:
- The startupType parameter has a [ValidateSet("delayed-auto", "auto")] attribute
- The default value is $null
- When invoked via iex without explicit parameters, PowerShell's parameter validation fails

Additionally, users have no documentation explaining:
- How to properly use the installation script with the new parameters
- What parameters are available
- The difference between delayed-auto and auto startup types

## Changes
This PR adds a new "Advanced Installation Options" section to the Windows installation documentation that includes:

- Working installation command that properly handles the startupType parameter using PowerShell's named parameter  syntax
- Complete parameter reference documenting all available options:
   - -startupType: Choose between 'delayed-auto' (default)  or 'auto' (immediate boot protection)
   - -silent: Enable non-interactive installation mode
   - -autostart: Control whether service starts immediately after installation
   - -uninstall: Uninstall IPBan
 - Example with multiple parameters demonstrating how to combine options
 - Important notes explaining the trade-offs between delayed-auto (safer, but brief vulnerability window after boot) and auto (immediate protection, but potential compatibility issues)

## Testing
All documented commands have been tested on Windows Server and confirmed to work correctly with the current installer script (commit 2e954a5).

## Impact
- Users can now successfully install IPBan using documented commands
- Clear guidance on customizing installation parameters
- Better understanding of security implications for each startup type option